### PR TITLE
fix(password): 使用 bcrypt 完成密码哈希与校验

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/ugorji/go/codec v1.3.1 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	golang.org/x/arch v0.25.0 // indirect
-	golang.org/x/crypto v0.49.0 // indirect
+	golang.org/x/crypto v0.49.0
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect

--- a/src/handler/handler.go
+++ b/src/handler/handler.go
@@ -314,12 +314,21 @@ func RegisterHandler(c *gin.Context) {
 
 	hashedPassword, err := utils.HashPassword(req.Password)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, newResponse(
-			c,
-			"Password hashing failed",
-			nil,
-			"PASSWORD_HASH_FAILED",
-		))
+		if errors.Is(err, utils.ErrPasswordTooLong) {
+			c.JSON(http.StatusBadRequest, newResponse(
+				c,
+				"Password is too long",
+				nil,
+				"PASSWORD_TOO_LONG",
+			))
+		} else {
+			c.JSON(http.StatusInternalServerError, newResponse(
+				c,
+				"Password hashing failed",
+				nil,
+				"PASSWORD_HASH_FAILED",
+			))
+		}
 		return
 	}
 	user := &models.User{

--- a/src/handler/handler.go
+++ b/src/handler/handler.go
@@ -71,8 +71,7 @@ func LoginHandler(c *gin.Context) {
 	}
 
 	user, err := models.FindUserByEmail(req.Email)
-
-	if err != nil || user.Password != req.Password {
+	if err != nil || !utils.CheckPassword(req.Password, user.Password) {
 		c.JSON(http.StatusUnauthorized, newResponse(
 			c,
 			"Invalid email or password",
@@ -312,10 +311,21 @@ func RegisterHandler(c *gin.Context) {
 		}
 		return
 	}
+
+	hashedPassword, err := utils.HashPassword(req.Password)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, newResponse(
+			c,
+			"Password hashing failed",
+			nil,
+			"PASSWORD_HASH_FAILED",
+		))
+		return
+	}
 	user := &models.User{
 		Username: req.Username,
 		Email:    req.Email,
-		Password: req.Password,
+		Password: hashedPassword,
 		RoleID:   0,
 	}
 

--- a/src/utils/password.go
+++ b/src/utils/password.go
@@ -1,11 +1,26 @@
 package utils
 
-import "golang.org/x/crypto/bcrypt"
+import (
+	"errors"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+const maxBcryptPasswordBytes = 72
 
 // HashPassword 生成密码哈希值。
 func HashPassword(password string) (string, error) {
-	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
-	return string(hashedPassword), err
+	passwordBytes := []byte(password)
+	if len(passwordBytes) > maxBcryptPasswordBytes {
+		return "", errors.New("password exceeds maximum length of 72 bytes for bcrypt")
+	}
+
+	hashedPassword, err := bcrypt.GenerateFromPassword(passwordBytes, bcrypt.DefaultCost)
+	if err != nil {
+		return "", err
+	}
+
+	return string(hashedPassword), nil
 }
 
 // CheckPassword 校验明文密码与哈希是否匹配。

--- a/src/utils/password.go
+++ b/src/utils/password.go
@@ -1,0 +1,14 @@
+package utils
+
+import "golang.org/x/crypto/bcrypt"
+
+// HashPassword 生成密码哈希值。
+func HashPassword(password string) (string, error) {
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	return string(hashedPassword), err
+}
+
+// CheckPassword 校验明文密码与哈希是否匹配。
+func CheckPassword(password, hash string) bool {
+	return bcrypt.CompareHashAndPassword([]byte(hash), []byte(password)) == nil
+}

--- a/src/utils/password.go
+++ b/src/utils/password.go
@@ -2,17 +2,20 @@ package utils
 
 import (
 	"errors"
+	"fmt"
 
 	"golang.org/x/crypto/bcrypt"
 )
 
 const maxBcryptPasswordBytes = 72
 
+var ErrPasswordTooLong = errors.New("password exceeds maximum length of 72 bytes for bcrypt")
+
 // HashPassword 生成密码哈希值。
 func HashPassword(password string) (string, error) {
 	passwordBytes := []byte(password)
 	if len(passwordBytes) > maxBcryptPasswordBytes {
-		return "", errors.New("password exceeds maximum length of 72 bytes for bcrypt")
+		return "", fmt.Errorf("%w", ErrPasswordTooLong)
 	}
 
 	hashedPassword, err := bcrypt.GenerateFromPassword(passwordBytes, bcrypt.DefaultCost)

--- a/src/utils/password_test.go
+++ b/src/utils/password_test.go
@@ -1,6 +1,9 @@
 package utils
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestHashPasswordAndCheckPassword(t *testing.T) {
 	hash, err := HashPassword("secret123")
@@ -28,14 +31,13 @@ func TestHashPasswordRejectsLongPasswords(t *testing.T) {
 		t.Fatal("test password must exceed 72 bytes")
 	}
 
-	_, err := HashPassword(longPassword)
+	hash, err := HashPassword(longPassword)
 	if err == nil {
 		t.Fatal("HashPassword should reject passwords longer than 72 bytes")
 	}
 
-	hash, err := HashPassword(longPassword)
-	if err == nil {
-		t.Fatal("HashPassword should reject passwords longer than 72 bytes")
+	if !errors.Is(err, ErrPasswordTooLong) {
+		t.Fatalf("HashPassword should return ErrPasswordTooLong, got %v", err)
 	}
 
 	if hash != "" {

--- a/src/utils/password_test.go
+++ b/src/utils/password_test.go
@@ -1,0 +1,22 @@
+package utils
+
+import "testing"
+
+func TestHashPasswordAndCheckPassword(t *testing.T) {
+	hash, err := HashPassword("secret123")
+	if err != nil {
+		t.Fatalf("HashPassword returned error: %v", err)
+	}
+
+	if hash == "secret123" {
+		t.Fatal("HashPassword should not return plain text password")
+	}
+
+	if !CheckPassword("secret123", hash) {
+		t.Fatal("CheckPassword should accept the correct password")
+	}
+
+	if CheckPassword("wrong-password", hash) {
+		t.Fatal("CheckPassword should reject an incorrect password")
+	}
+}

--- a/src/utils/password_test.go
+++ b/src/utils/password_test.go
@@ -20,3 +20,25 @@ func TestHashPasswordAndCheckPassword(t *testing.T) {
 		t.Fatal("CheckPassword should reject an incorrect password")
 	}
 }
+
+func TestHashPasswordRejectsLongPasswords(t *testing.T) {
+	longPassword := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	if len([]byte(longPassword)) <= maxBcryptPasswordBytes {
+		t.Fatal("test password must exceed 72 bytes")
+	}
+
+	_, err := HashPassword(longPassword)
+	if err == nil {
+		t.Fatal("HashPassword should reject passwords longer than 72 bytes")
+	}
+
+	hash, err := HashPassword(longPassword)
+	if err == nil {
+		t.Fatal("HashPassword should reject passwords longer than 72 bytes")
+	}
+
+	if hash != "" {
+		t.Fatal("HashPassword should return an empty string when hashing fails")
+	}
+}


### PR DESCRIPTION
**描述**
本 PR 对应 BE-001，完成密码哈希的 bcrypt 改造，避免明文密码存储，并补充基础测试覆盖。

**变更内容**
- 新增密码哈希工具，使用 bcrypt 生成密码摘要
- 注册流程改为保存 bcrypt 哈希，不再存储明文密码
- 登录流程改为使用 bcrypt 校验密码
- 增加基础单元测试，覆盖哈希生成与密码校验

**验证**
- 密码相关单元测试已通过
- 相关逻辑已完成本地检查

**关联 Issue**
- Closes #2