### PR TITLE
feat: 新增category与tag功能模块

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func main() {
 	defer dao.MyClose()
 
 	// 模型绑定
-	if err := dao.DB.AutoMigrate(&models.User{}, &models.Article{}, &models.Category{}, &models.Tag{}); err != nil {
+	if err := dao.DB.AutoMigrate(&models.User{}, &models.Category{}, &models.Tag{}, &models.Article{}); err != nil {
 		log.Fatal("数据库迁移失败：", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func main() {
 	defer dao.MyClose()
 
 	// 模型绑定
-	if err := dao.DB.AutoMigrate(&models.User{}, &models.Article{}); err != nil {
+	if err := dao.DB.AutoMigrate(&models.User{}, &models.Article{}, &models.Category{}, &models.Tag{}); err != nil {
 		log.Fatal("数据库迁移失败：", err)
 	}
 

--- a/src/handler/category_handler.go
+++ b/src/handler/category_handler.go
@@ -1,0 +1,29 @@
+package handler
+
+import (
+	"blog-BE/src/models"
+	"blog-BE/src/utils"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func GetCategories(c *gin.Context) {
+	categories, err := models.GetCategories()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, utils.NewResponse(
+			c,
+			"获取分类失败",
+			nil,
+			"DATABASE_ERROR",
+		))
+		return
+	}
+
+	c.JSON(http.StatusOK, utils.NewResponse(
+		c,
+		"success",
+		categories,
+		"",
+	))
+}

--- a/src/handler/tag_handler.go
+++ b/src/handler/tag_handler.go
@@ -1,0 +1,29 @@
+package handler
+
+import (
+	"blog-BE/src/models"
+	"blog-BE/src/utils"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func GetTags(c *gin.Context) {
+	tags, err := models.GetTags()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, utils.NewResponse(
+			c,
+			"获取标签失败",
+			nil,
+			"DATABASE_ERROR",
+		))
+		return
+	}
+
+	c.JSON(http.StatusOK, utils.NewResponse(
+		c,
+		"success",
+		tags,
+		"",
+	))
+}

--- a/src/models/article.go
+++ b/src/models/article.go
@@ -15,6 +15,9 @@ type Article struct {
 	CoverImage string         `gorm:"size:255" json:"cover_image"`
 	AuthorID   uint           `gorm:"not null;index" json:"author_id"`
 	Author     *User          `gorm:"foreignKey:AuthorID" json:"author,omitempty"`
+	CategoryID *uint          `gorm:"index" json:"category_id"`
+	Category   *Category      `gorm:"foreignKey:CategoryID" json:"category,omitempty"`
+	Tags       []Tag          `gorm:"many2many:article_tags" json:"tags,omitempty"`
 	Status     string         `gorm:"size:20;default:draft;index" json:"status"`
 	ViewCount  int            `gorm:"default:0" json:"view_count"`
 	CreatedAt  time.Time      `json:"created_at"`
@@ -100,4 +103,20 @@ func IncrementViewCount(id uint) error {
 	return dao.DB.Model(&Article{}).
 		Where("id = ?", id).
 		UpdateColumn("view_count", gorm.Expr("view_count + 1")).Error
+}
+
+func UpdateArticleTags(articleID uint, tagIDs []uint) error {
+	var article Article
+	if err := dao.DB.First(&article, articleID).Error; err != nil {
+		return err
+	}
+
+	tags := make([]Tag, 0, len(tagIDs))
+	if len(tagIDs) > 0 {
+		if err := dao.DB.Where("id IN ?", tagIDs).Find(&tags).Error; err != nil {
+			return err
+		}
+	}
+
+	return dao.DB.Model(&article).Association("Tags").Replace(tags)
 }

--- a/src/models/article.go
+++ b/src/models/article.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"blog-BE/src/dao"
+	"errors"
 	"time"
 
 	"gorm.io/gorm"
@@ -111,10 +112,23 @@ func UpdateArticleTags(articleID uint, tagIDs []uint) error {
 		return err
 	}
 
-	tags := make([]Tag, 0, len(tagIDs))
-	if len(tagIDs) > 0 {
-		if err := dao.DB.Where("id IN ?", tagIDs).Find(&tags).Error; err != nil {
+	uniqueTagIDs := make([]uint, 0, len(tagIDs))
+	seen := make(map[uint]struct{}, len(tagIDs))
+	for _, tagID := range tagIDs {
+		if _, ok := seen[tagID]; ok {
+			continue
+		}
+		seen[tagID] = struct{}{}
+		uniqueTagIDs = append(uniqueTagIDs, tagID)
+	}
+
+	tags := make([]Tag, 0, len(uniqueTagIDs))
+	if len(uniqueTagIDs) > 0 {
+		if err := dao.DB.Where("id IN ?", uniqueTagIDs).Find(&tags).Error; err != nil {
 			return err
+		}
+		if len(tags) != len(uniqueTagIDs) {
+			return errors.New("one or more tag IDs are invalid")
 		}
 	}
 

--- a/src/models/category.go
+++ b/src/models/category.go
@@ -1,0 +1,37 @@
+package models
+
+import (
+	"blog-BE/src/dao"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type Category struct {
+	ID          uint           `gorm:"primaryKey" json:"id"`
+	Name        string         `gorm:"size:50;not null;uniqueIndex" json:"name"`
+	Slug        string         `gorm:"size:50;uniqueIndex" json:"slug"`
+	Description string         `gorm:"size:255" json:"description"`
+	ParentID    *uint          `gorm:"index" json:"parent_id"`
+	Parent      *Category      `gorm:"foreignKey:ParentID" json:"parent,omitempty"`
+	SortOrder   int            `gorm:"default:0" json:"sort_order"`
+	CreatedAt   time.Time      `json:"created_at"`
+	UpdatedAt   time.Time      `json:"updated_at"`
+	DeletedAt   gorm.DeletedAt `gorm:"index" json:"-"`
+}
+
+func GetCategories() ([]Category, error) {
+	var categories []Category
+	err := dao.DB.Where("parent_id IS NULL").Order("sort_order ASC").Find(&categories).Error
+	return categories, err
+}
+
+func GetCategoryByID(id uint) (*Category, error) {
+	var category Category
+	err := dao.DB.First(&category, id).Error
+	return &category, err
+}
+
+func CreateCategory(category *Category) error {
+	return dao.DB.Create(category).Error
+}

--- a/src/models/category.go
+++ b/src/models/category.go
@@ -3,6 +3,7 @@ package models
 import (
 	"blog-BE/src/dao"
 	"fmt"
+	"strings"
 	"time"
 
 	"gorm.io/gorm"
@@ -36,6 +37,11 @@ func GetCategoryByID(id uint) (*Category, error) {
 func CreateCategory(category *Category) error {
 	var lastErr error
 	for attempt := 0; attempt < 3; attempt++ {
+		category.Name = strings.TrimSpace(category.Name)
+		if category.Name == "" {
+			return fmt.Errorf("category name cannot be empty")
+		}
+
 		slug, err := buildUniqueSlug(&Category{}, firstNonEmpty(category.Slug, category.Name), 50)
 		if err != nil {
 			return err

--- a/src/models/category.go
+++ b/src/models/category.go
@@ -10,8 +10,8 @@ import (
 
 type Category struct {
 	ID          uint           `gorm:"primaryKey" json:"id"`
-	Name        string         `gorm:"size:50;not null;uniqueIndex" json:"name"`
-	Slug        string         `gorm:"size:50;uniqueIndex" json:"slug"`
+	Name        string         `gorm:"size:50;not null;uniqueIndex:idx_categories_name_active,where:deleted_at IS NULL" json:"name"`
+	Slug        string         `gorm:"size:50;uniqueIndex:idx_categories_slug_active,where:deleted_at IS NULL" json:"slug"`
 	Description string         `gorm:"size:255" json:"description"`
 	ParentID    *uint          `gorm:"index" json:"parent_id"`
 	Parent      *Category      `gorm:"foreignKey:ParentID" json:"parent,omitempty"`

--- a/src/models/category.go
+++ b/src/models/category.go
@@ -44,7 +44,7 @@ func CreateCategory(category *Category) error {
 
 		if err := dao.DB.Create(category).Error; err != nil {
 			lastErr = err
-			if isUniqueConstraintError(err) {
+			if isSlugUniqueConstraintError(err) {
 				continue
 			}
 			return err

--- a/src/models/category.go
+++ b/src/models/category.go
@@ -23,7 +23,7 @@ type Category struct {
 
 func GetCategories() ([]Category, error) {
 	var categories []Category
-	err := dao.DB.Order("parent_id ASC").Order("sort_order ASC").Find(&categories).Error
+	err := dao.DB.Order("parent_id ASC NULLS FIRST").Order("sort_order ASC").Find(&categories).Error
 	return categories, err
 }
 

--- a/src/models/category.go
+++ b/src/models/category.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"blog-BE/src/dao"
+	"fmt"
 	"time"
 
 	"gorm.io/gorm"
@@ -33,11 +34,28 @@ func GetCategoryByID(id uint) (*Category, error) {
 }
 
 func CreateCategory(category *Category) error {
-	slug, err := buildUniqueSlug(&Category{}, firstNonEmpty(category.Slug, category.Name), 50)
-	if err != nil {
-		return err
-	}
-	category.Slug = slug
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		slug, err := buildUniqueSlug(&Category{}, firstNonEmpty(category.Slug, category.Name), 50)
+		if err != nil {
+			return err
+		}
+		category.Slug = slug
 
-	return dao.DB.Create(category).Error
+		if err := dao.DB.Create(category).Error; err != nil {
+			lastErr = err
+			if isUniqueConstraintError(err) {
+				continue
+			}
+			return err
+		}
+
+		return nil
+	}
+
+	if lastErr != nil {
+		return lastErr
+	}
+
+	return fmt.Errorf("failed to create category after retries")
 }

--- a/src/models/category.go
+++ b/src/models/category.go
@@ -33,5 +33,11 @@ func GetCategoryByID(id uint) (*Category, error) {
 }
 
 func CreateCategory(category *Category) error {
+	slug, err := buildUniqueSlug(&Category{}, firstNonEmpty(category.Slug, category.Name), 50)
+	if err != nil {
+		return err
+	}
+	category.Slug = slug
+
 	return dao.DB.Create(category).Error
 }

--- a/src/models/category.go
+++ b/src/models/category.go
@@ -22,7 +22,7 @@ type Category struct {
 
 func GetCategories() ([]Category, error) {
 	var categories []Category
-	err := dao.DB.Where("parent_id IS NULL").Order("sort_order ASC").Find(&categories).Error
+	err := dao.DB.Order("parent_id ASC").Order("sort_order ASC").Find(&categories).Error
 	return categories, err
 }
 

--- a/src/models/category.go
+++ b/src/models/category.go
@@ -54,7 +54,7 @@ func CreateCategory(category *Category) error {
 	}
 
 	if lastErr != nil {
-		return lastErr
+		return fmt.Errorf("failed to create category after retries: %w", lastErr)
 	}
 
 	return fmt.Errorf("failed to create category after retries")

--- a/src/models/slug.go
+++ b/src/models/slug.go
@@ -92,3 +92,12 @@ func isUniqueConstraintError(err error) bool {
 
 	return errors.Is(err, gorm.ErrDuplicatedKey) || strings.Contains(strings.ToLower(err.Error()), "duplicate key value violates unique constraint")
 }
+
+func isSlugUniqueConstraintError(err error) bool {
+	if !isUniqueConstraintError(err) {
+		return false
+	}
+
+	lowerErr := strings.ToLower(err.Error())
+	return strings.Contains(lowerErr, "slug")
+}

--- a/src/models/slug.go
+++ b/src/models/slug.go
@@ -20,7 +20,7 @@ func buildUniqueSlug(model any, rawValue string, maxLength int) (string, error) 
 
 	for suffix := 2; ; suffix++ {
 		var count int64
-		if err := dao.DB.Unscoped().Model(model).Where("slug = ?", slug).Count(&count).Error; err != nil {
+		if err := dao.DB.Model(model).Where("slug = ?", slug).Count(&count).Error; err != nil {
 			return "", err
 		}
 		if count == 0 {

--- a/src/models/slug.go
+++ b/src/models/slug.go
@@ -2,8 +2,11 @@ package models
 
 import (
 	"blog-BE/src/dao"
+	"errors"
 	"fmt"
 	"strings"
+
+	"gorm.io/gorm"
 )
 
 func buildUniqueSlug(model any, rawValue string, maxLength int) (string, error) {
@@ -17,7 +20,7 @@ func buildUniqueSlug(model any, rawValue string, maxLength int) (string, error) 
 
 	for suffix := 2; ; suffix++ {
 		var count int64
-		if err := dao.DB.Model(model).Where("slug = ?", slug).Count(&count).Error; err != nil {
+		if err := dao.DB.Unscoped().Model(model).Where("slug = ?", slug).Count(&count).Error; err != nil {
 			return "", err
 		}
 		if count == 0 {
@@ -70,4 +73,22 @@ func truncateSlug(value string, maxLength int) string {
 	}
 
 	return strings.Trim(value[:maxLength], "-")
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+
+	return ""
+}
+
+func isUniqueConstraintError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return errors.Is(err, gorm.ErrDuplicatedKey) || strings.Contains(strings.ToLower(err.Error()), "duplicate key value violates unique constraint")
 }

--- a/src/models/slug.go
+++ b/src/models/slug.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"unicode"
 
 	"gorm.io/gorm"
 )
@@ -53,7 +54,7 @@ func normalizeSlugBase(rawValue string) string {
 
 	for _, r := range rawValue {
 		switch {
-		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+		case unicode.IsLetter(r), unicode.IsDigit(r):
 			builder.WriteRune(r)
 			lastWasHyphen = false
 		case r == ' ' || r == '-' || r == '_' || r == '.' || r == '/':
@@ -68,11 +69,16 @@ func normalizeSlugBase(rawValue string) string {
 }
 
 func truncateSlug(value string, maxLength int) string {
-	if maxLength <= 0 || len(value) <= maxLength {
+	if maxLength <= 0 {
+		return ""
+	}
+
+	runes := []rune(value)
+	if len(runes) <= maxLength {
 		return value
 	}
 
-	return strings.Trim(value[:maxLength], "-")
+	return strings.Trim(string(runes[:maxLength]), "-")
 }
 
 func firstNonEmpty(values ...string) string {

--- a/src/models/slug.go
+++ b/src/models/slug.go
@@ -1,0 +1,73 @@
+package models
+
+import (
+	"blog-BE/src/dao"
+	"fmt"
+	"strings"
+)
+
+func buildUniqueSlug(model any, rawValue string, maxLength int) (string, error) {
+	slugBase := normalizeSlugBase(rawValue)
+	if slugBase == "" {
+		slugBase = "item"
+	}
+
+	slugBase = truncateSlug(slugBase, maxLength)
+	slug := slugBase
+
+	for suffix := 2; ; suffix++ {
+		var count int64
+		if err := dao.DB.Model(model).Where("slug = ?", slug).Count(&count).Error; err != nil {
+			return "", err
+		}
+		if count == 0 {
+			return slug, nil
+		}
+
+		suffixText := fmt.Sprintf("-%d", suffix)
+		baseLimit := maxLength - len(suffixText)
+		if baseLimit < 1 {
+			return "", fmt.Errorf("slug max length %d is too short", maxLength)
+		}
+
+		candidateBase := truncateSlug(slugBase, baseLimit)
+		if candidateBase == "" {
+			candidateBase = "item"
+		}
+		slug = candidateBase + suffixText
+	}
+}
+
+func normalizeSlugBase(rawValue string) string {
+	rawValue = strings.ToLower(strings.TrimSpace(rawValue))
+	if rawValue == "" {
+		return ""
+	}
+
+	var builder strings.Builder
+	builder.Grow(len(rawValue))
+	lastWasHyphen := false
+
+	for _, r := range rawValue {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			builder.WriteRune(r)
+			lastWasHyphen = false
+		case r == ' ' || r == '-' || r == '_' || r == '.' || r == '/':
+			if builder.Len() > 0 && !lastWasHyphen {
+				builder.WriteByte('-')
+				lastWasHyphen = true
+			}
+		}
+	}
+
+	return strings.Trim(builder.String(), "-")
+}
+
+func truncateSlug(value string, maxLength int) string {
+	if maxLength <= 0 || len(value) <= maxLength {
+		return value
+	}
+
+	return strings.Trim(value[:maxLength], "-")
+}

--- a/src/models/tag.go
+++ b/src/models/tag.go
@@ -12,8 +12,8 @@ import (
 
 type Tag struct {
 	ID        uint           `gorm:"primaryKey" json:"id"`
-	Name      string         `gorm:"size:30;not null;uniqueIndex" json:"name"`
-	Slug      string         `gorm:"size:30;uniqueIndex" json:"slug"`
+	Name      string         `gorm:"size:30;not null;uniqueIndex:idx_tags_name_active,where:deleted_at IS NULL" json:"name"`
+	Slug      string         `gorm:"size:30;uniqueIndex:idx_tags_slug_active,where:deleted_at IS NULL" json:"slug"`
 	Color     string         `gorm:"size:7;default:#6366f1" json:"color"`
 	CreatedAt time.Time      `json:"created_at"`
 	UpdatedAt time.Time      `json:"updated_at"`

--- a/src/models/tag.go
+++ b/src/models/tag.go
@@ -32,6 +32,12 @@ func GetTagByID(id uint) (*Tag, error) {
 }
 
 func CreateTag(tag *Tag) error {
+	slug, err := buildUniqueSlug(&Tag{}, firstNonEmpty(tag.Slug, tag.Name), 30)
+	if err != nil {
+		return err
+	}
+	tag.Slug = slug
+
 	return dao.DB.Create(tag).Error
 }
 
@@ -51,11 +57,8 @@ func GetOrCreateTags(names []string) ([]Tag, error) {
 				return nil, err
 			}
 
-			tag = Tag{
-				Name: trimmedName,
-				Slug: strings.ToLower(trimmedName),
-			}
-			if err := dao.DB.Create(&tag).Error; err != nil {
+			tag = Tag{Name: trimmedName}
+			if err := CreateTag(&tag); err != nil {
 				return nil, err
 			}
 		}
@@ -64,4 +67,14 @@ func GetOrCreateTags(names []string) ([]Tag, error) {
 	}
 
 	return tags, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+
+	return ""
 }

--- a/src/models/tag.go
+++ b/src/models/tag.go
@@ -3,6 +3,7 @@ package models
 import (
 	"blog-BE/src/dao"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -32,13 +33,30 @@ func GetTagByID(id uint) (*Tag, error) {
 }
 
 func CreateTag(tag *Tag) error {
-	slug, err := buildUniqueSlug(&Tag{}, firstNonEmpty(tag.Slug, tag.Name), 30)
-	if err != nil {
-		return err
-	}
-	tag.Slug = slug
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		slug, err := buildUniqueSlug(&Tag{}, firstNonEmpty(tag.Slug, tag.Name), 30)
+		if err != nil {
+			return err
+		}
+		tag.Slug = slug
 
-	return dao.DB.Create(tag).Error
+		if err := dao.DB.Create(tag).Error; err != nil {
+			lastErr = err
+			if isUniqueConstraintError(err) {
+				continue
+			}
+			return err
+		}
+
+		return nil
+	}
+
+	if lastErr != nil {
+		return lastErr
+	}
+
+	return fmt.Errorf("failed to create tag after retries")
 }
 
 func GetOrCreateTags(names []string) ([]Tag, error) {
@@ -67,14 +85,4 @@ func GetOrCreateTags(names []string) ([]Tag, error) {
 	}
 
 	return tags, nil
-}
-
-func firstNonEmpty(values ...string) string {
-	for _, value := range values {
-		if trimmed := strings.TrimSpace(value); trimmed != "" {
-			return trimmed
-		}
-	}
-
-	return ""
 }

--- a/src/models/tag.go
+++ b/src/models/tag.go
@@ -43,7 +43,7 @@ func CreateTag(tag *Tag) error {
 
 		if err := dao.DB.Create(tag).Error; err != nil {
 			lastErr = err
-			if isUniqueConstraintError(err) {
+			if isSlugUniqueConstraintError(err) {
 				continue
 			}
 			return err

--- a/src/models/tag.go
+++ b/src/models/tag.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"blog-BE/src/dao"
+	"errors"
 	"strings"
 	"time"
 
@@ -46,7 +47,7 @@ func GetOrCreateTags(names []string) ([]Tag, error) {
 		var tag Tag
 		err := dao.DB.Where("name = ?", trimmedName).First(&tag).Error
 		if err != nil {
-			if err != gorm.ErrRecordNotFound {
+			if !errors.Is(err, gorm.ErrRecordNotFound) {
 				return nil, err
 			}
 

--- a/src/models/tag.go
+++ b/src/models/tag.go
@@ -36,6 +36,10 @@ func CreateTag(tag *Tag) error {
 	var lastErr error
 	for attempt := 0; attempt < 3; attempt++ {
 		tag.Name = strings.ToLower(strings.TrimSpace(tag.Name))
+		if tag.Name == "" {
+			return errors.New("tag name cannot be empty")
+		}
+
 		slug, err := buildUniqueSlug(&Tag{}, firstNonEmpty(tag.Slug, tag.Name), 30)
 		if err != nil {
 			return err

--- a/src/models/tag.go
+++ b/src/models/tag.go
@@ -61,6 +61,7 @@ func CreateTag(tag *Tag) error {
 
 func GetOrCreateTags(names []string) ([]Tag, error) {
 	tags := make([]Tag, 0, len(names))
+	seen := make(map[string]struct{}, len(names))
 
 	for _, name := range names {
 		trimmedName := strings.TrimSpace(name)
@@ -68,8 +69,14 @@ func GetOrCreateTags(names []string) ([]Tag, error) {
 			continue
 		}
 
+		normalizedName := strings.ToLower(trimmedName)
+		if _, ok := seen[normalizedName]; ok {
+			continue
+		}
+		seen[normalizedName] = struct{}{}
+
 		var tag Tag
-		err := dao.DB.Where("name = ?", trimmedName).First(&tag).Error
+		err := dao.DB.Where("LOWER(name) = LOWER(?)", trimmedName).First(&tag).Error
 		if err != nil {
 			if !errors.Is(err, gorm.ErrRecordNotFound) {
 				return nil, err

--- a/src/models/tag.go
+++ b/src/models/tag.go
@@ -35,6 +35,7 @@ func GetTagByID(id uint) (*Tag, error) {
 func CreateTag(tag *Tag) error {
 	var lastErr error
 	for attempt := 0; attempt < 3; attempt++ {
+		tag.Name = strings.ToLower(strings.TrimSpace(tag.Name))
 		slug, err := buildUniqueSlug(&Tag{}, firstNonEmpty(tag.Slug, tag.Name), 30)
 		if err != nil {
 			return err
@@ -53,7 +54,7 @@ func CreateTag(tag *Tag) error {
 	}
 
 	if lastErr != nil {
-		return lastErr
+		return fmt.Errorf("failed to create tag after retries: %w", lastErr)
 	}
 
 	return fmt.Errorf("failed to create tag after retries")
@@ -76,7 +77,10 @@ func GetOrCreateTags(names []string) ([]Tag, error) {
 		seen[normalizedName] = struct{}{}
 
 		var tag Tag
-		err := dao.DB.Where("LOWER(name) = LOWER(?)", trimmedName).First(&tag).Error
+		err := dao.DB.Where("name = ?", normalizedName).First(&tag).Error
+		if err != nil && errors.Is(err, gorm.ErrRecordNotFound) {
+			err = dao.DB.Where("LOWER(name) = LOWER(?)", trimmedName).First(&tag).Error
+		}
 		if err != nil {
 			if !errors.Is(err, gorm.ErrRecordNotFound) {
 				return nil, err

--- a/src/models/tag.go
+++ b/src/models/tag.go
@@ -1,0 +1,66 @@
+package models
+
+import (
+	"blog-BE/src/dao"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type Tag struct {
+	ID        uint           `gorm:"primaryKey" json:"id"`
+	Name      string         `gorm:"size:30;not null;uniqueIndex" json:"name"`
+	Slug      string         `gorm:"size:30;uniqueIndex" json:"slug"`
+	Color     string         `gorm:"size:7;default:#6366f1" json:"color"`
+	CreatedAt time.Time      `json:"created_at"`
+	UpdatedAt time.Time      `json:"updated_at"`
+	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
+}
+
+func GetTags() ([]Tag, error) {
+	var tags []Tag
+	err := dao.DB.Order("name ASC").Find(&tags).Error
+	return tags, err
+}
+
+func GetTagByID(id uint) (*Tag, error) {
+	var tag Tag
+	err := dao.DB.First(&tag, id).Error
+	return &tag, err
+}
+
+func CreateTag(tag *Tag) error {
+	return dao.DB.Create(tag).Error
+}
+
+func GetOrCreateTags(names []string) ([]Tag, error) {
+	tags := make([]Tag, 0, len(names))
+
+	for _, name := range names {
+		trimmedName := strings.TrimSpace(name)
+		if trimmedName == "" {
+			continue
+		}
+
+		var tag Tag
+		err := dao.DB.Where("name = ?", trimmedName).First(&tag).Error
+		if err != nil {
+			if err != gorm.ErrRecordNotFound {
+				return nil, err
+			}
+
+			tag = Tag{
+				Name: trimmedName,
+				Slug: strings.ToLower(trimmedName),
+			}
+			if err := dao.DB.Create(&tag).Error; err != nil {
+				return nil, err
+			}
+		}
+
+		tags = append(tags, tag)
+	}
+
+	return tags, nil
+}

--- a/src/routers/router.go
+++ b/src/routers/router.go
@@ -20,6 +20,9 @@ func SetupRouter() *gin.Engine {
 
 	v1 := router.Group("/api/v1")
 	{
+		v1.GET("/categories", handler.GetCategories)
+		v1.GET("/tags", handler.GetTags)
+
 		articles := v1.Group("/articles")
 		articles.GET("", handler.GetArticles)
 		articles.GET("/:id", handler.GetArticle)


### PR DESCRIPTION
### Summary
本次新增文章分类和标签基础能力，支持分类层级结构、标签颜色配置，并为文章模型补充分类和多标签关联。同步开放分类与标签列表查询接口，并将新模型纳入自动迁移。

### Changes
- 新增分类模型，支持 parent_id 层级结构、排序和软删除。
- 新增标签模型，支持名称、Slug、颜色配置和软删除。
- 更新文章模型，增加分类关联和多对多标签关联。
- 新增文章标签更新方法。
- 新增分类列表接口。
- 新增标签列表接口。
- 更新启动迁移逻辑，纳入新模型。

### API
- GET /api/v1/categories
- GET /api/v1/tags

### Impact
- 数据模型：新增分类、标签表及文章关联字段。
- 接口层：新增分类与标签查询接口。
- 数据库：新增自动迁移表结构。
- 文章功能：为后续文章绑定分类和标签提供基础能力。

### Testing
- 已执行 go test ./...
- 全部包编译通过，无新增错误。

### Notes
- 当前仅完成分类和标签的基础模块与列表查询。
- 文章创建和更新接口尚未接入分类选择和标签写入，后续可继续补充。
- 运行自动迁移后，数据库会新增相关表和字段，请确认线上环境迁移策略。

### Files
- category.go
- tag.go
- article.go
- category_handler.go
- tag_handler.go
- router.go
- main.go

### Related Issue
- Resolves #5