### PR TITLE
fix(config): 修正本地开发配置默认值并补充 CORS 来源

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # 数据库配置 (以 PostgreSQL 为例)
 DB_HOST=localhost
 DB_PORT=5432
-DB_HOST_PORT=5432
+DB_HOST_PORT=5433
 DB_USER=admin
 DB_PASSWORD=your_secure_password_here
 DB_NAME=mydb
@@ -31,7 +31,7 @@ JWT_ACCESS_TTL=15m
 JWT_REFRESH_TTL=168h
 
 # CORS 配置
-CORS_ALLOW_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+CORS_ALLOW_ORIGINS=http://localhost:3000,http://127.0.0.1:3000,http://localhost:5173,http://127.0.0.1:5173
 CORS_ALLOW_METHODS=GET,POST,PUT,PATCH,DELETE,OPTIONS
 CORS_ALLOW_HEADERS=Origin,Content-Type,Accept,Authorization,X-Requested-With
 CORS_EXPOSE_HEADERS=Content-Length

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       POSTGRES_DB: ${DB_NAME}
       TZ: Asia/Shanghai
     ports:
-      - "${DB_HOST_PORT:-5432}:5432"
+      - "${DB_HOST_PORT:-5433}:5432"
     volumes:
       # 数据持久化
       - postgres_data:/var/lib/postgresql/data


### PR DESCRIPTION
### 变更说明
修正本地开发相关配置，统一数据库端口默认值，并补充前端开发常用端口的 CORS 白名单。

### 主要改动
- 调整 PostgreSQL 默认映射端口为 5433
- 同步更新示例环境变量中的 DB_HOST_PORT
- 补充 5173 的 CORS 允许来源

### 验证
- 已重新构建并启动 Docker Compose
- 确认数据库端口映射生效，宿主机端口为 5433
- 已确认配置变更符合本地开发场景